### PR TITLE
Fix caching when using redis-cache

### DIFF
--- a/parler/cache.py
+++ b/parler/cache.py
@@ -15,7 +15,7 @@ if six.PY3:
 
 try:
     DEFAULT_TIMEOUT = cache.cache.default_timeout
-except ImportError:
+except AttributeError:
     DEFAULT_TIMEOUT = 0
 
 

--- a/parler/cache.py
+++ b/parler/cache.py
@@ -14,9 +14,7 @@ if six.PY3:
     long = int
 
 try:
-    # In Django 1.6, a timeout of 0 seconds is accepted as valid input,
-    # and a sentinel value is used to denote the default timeout. Use that.
-    from django.core.cache.backends.base import DEFAULT_TIMEOUT
+    DEFAULT_TIMEOUT = cache.cache.default_timeout
 except ImportError:
     DEFAULT_TIMEOUT = 0
 


### PR DESCRIPTION
@vdboor This will fix caching issue when using redis-cache, because the default Django `DEFAULT_TIMEOUT` is an object redis tries to cast it to integer.

It would be nice to provide this as a parler setting to override the cache timeout.