### PR TITLE
Exception RelatedObjectDoesNotExist in admin - model with foreign key (not null)

### DIFF
--- a/parler/forms.py
+++ b/parler/forms.py
@@ -58,7 +58,7 @@ class TranslatableModelFormMixin(object):
                     pass
                 else:
                     for field in meta.get_translated_fields():
-                        self.initial.setdefault(field, getattr(translation, field))
+                        self.initial.setdefault(field, getattr(translation, field, None))
 
         # Typically already set by admin
         if self.language_code is None:

--- a/parler/tests/forms.py
+++ b/parler/tests/forms.py
@@ -3,7 +3,7 @@ from django.core.exceptions import ValidationError
 from django.utils import translation
 from parler.forms import TranslatableModelForm
 from .utils import AppTestCase
-from .testapp.models import SimpleModel, UniqueTogetherModel
+from .testapp.models import SimpleModel, UniqueTogetherModel, ForeignKeyTranslationModel, RegularModel
 
 
 class SimpleForm(TranslatableModelForm):
@@ -16,6 +16,13 @@ class SimpleForm(TranslatableModelForm):
 class UniqueTogetherForm(TranslatableModelForm):
     class Meta:
         model = UniqueTogetherModel
+        if django.VERSION >= (1,6):
+            fields = '__all__'
+
+
+class ForeignKeyTranslationModelForm(TranslatableModelForm):
+    class Meta:
+        model = ForeignKeyTranslationModel
         if django.VERSION >= (1,6):
             fields = '__all__'
 
@@ -68,3 +75,23 @@ class FormTests(AppTestCase):
         form.language_code = 'en'
         self.assertFalse(form.is_valid())
         self.assertRaises(ValidationError, lambda: form.instance.validate_unique())
+
+
+    def test_not_null_foreignkey_in_translation(self):
+        """
+        Simulate scenario for model with translation field of type foreign key (not null).
+          1. User create model with one translation (EN)
+          2. Switch to another language in admin (FR)
+        """
+
+        # create object with translation
+        r1 = RegularModel.objects.create(original_field='r1')
+        a = ForeignKeyTranslationModel.objects.create(translated_foreign=r1, shared='EN')
+
+        # same way as TranslatableAdmin.get_object() inicializing translation, when user swich to new translation language
+        a.set_current_language('fr', initialize=True)
+
+        # inicialize form
+        form = ForeignKeyTranslationModelForm(instance=a)
+
+        self.assertTrue(True)

--- a/parler/tests/testapp/models.py
+++ b/parler/tests/testapp/models.py
@@ -118,9 +118,11 @@ class ProxyModel(ProxyBase):
 class DoubleModel(TranslatableModel):
     shared = models.CharField(max_length=200, default='')
 
+
 class DoubleModelTranslations(TranslatedFieldsModel):
     master = models.ForeignKey(DoubleModel, related_name='base_translations')
     l1_title = models.CharField(max_length=200)
+
 
 class DoubleModelMoreTranslations(TranslatedFieldsModel):
     master = models.ForeignKey(DoubleModel, related_name='more_translations')
@@ -135,6 +137,14 @@ class RegularModel(models.Model):
 class CharModel(TranslatableModel):
     id = models.CharField(max_length=45, primary_key=True)
 
+
 class CharModelTranslation(TranslatedFieldsModel):
     master = models.ForeignKey(CharModel)
     tr_title = models.CharField(max_length=200)
+
+
+class ForeignKeyTranslationModel(TranslatableModel):
+    translations = TranslatedFields(
+        translated_foreign = models.ForeignKey('RegularModel'),
+    )
+    shared = models.CharField(max_length=200)


### PR DESCRIPTION
TranslatableAdmin class raise RelatedObjectDoesNotExist when user go to untranslated model language.

# Scenario
1. User in admin create new object of ForeignKeyTranslationModel with translation (EN)
2. User try to open another translation tab (FR) of object from previous step.


# Code
``` python
# ./models.py
class RegularModel(models.Model):
    # Normal model without translations. Test how replacing the field works.
    original_field = models.CharField(default="untranslated", max_length=255)

class ForeignKeyTranslationModel(TranslatableModel):
    translations = TranslatedFields(
        translated_foreign = models.ForeignKey('RegularModel'),
        # translated_foreign = models.ForeignKey('RegularModel', null=True) # do not raise exception
    )
    shared = models.CharField(max_length=200)
```

``` python
# ./admin.py
class ForeignKeyTranslationModelAdmin(TranslatableAdmin):
    pass
admin.site.register(ForeignKeyTranslationModel, ForeignKeyTranslationModelAdmin)
```

# Exception
Note: Is stacktrace from regular code, not dummy one above.
```
RelatedObjectDoesNotExist at /admin/quotes/author/24610/
AuthorTranslation has no name.

Environment:


Request Method: GET
Request URL: http://localhost:8000/admin/quotes/author/24610/?language=pt

Django Version: 1.8
Python Version: 3.4.2
Installed Applications:
('django.contrib.auth',
 'django.contrib.contenttypes',
 'django.contrib.sessions',
 'django.contrib.messages',
 'django.contrib.admin',
 'django.contrib.sites',
 'django.contrib.staticfiles',
 'django.contrib.sitemaps',
 'django.contrib.redirects',
 'compressor',
 'django_jinja',
 'django_jinja.contrib._humanize',
 'parler',
 'smoked',
 'citaty.quotes',
 'citaty.thumbrating',
 'citaty.pagination',
 'citaty.quotes2',
 'debug_toolbar')
Installed Middleware:
('django.middleware.common.CommonMiddleware',
 'django.contrib.sessions.middleware.SessionMiddleware',
 'django.middleware.csrf.CsrfViewMiddleware',
 'django.contrib.auth.middleware.AuthenticationMiddleware',
 'django.contrib.messages.middleware.MessageMiddleware',
 'citaty.pagination.middleware.RedirectIgnorePageFallbackMiddleware',
 'citaty.utils.middleware.SetRemoteAddrFromForwardedFor',
 'citaty.pagination.middleware.RedirectFromEmptyPage',
 'debug_toolbar.middleware.DebugToolbarMiddleware')


Traceback:
File "W:\.venv\citaty\lib\site-packages\django\core\handlers\base.py" in get_response
  132.                     response = wrapped_callback(request, *callback_args, **callback_kwargs)
File "W:\.venv\citaty\lib\site-packages\django\contrib\admin\options.py" in wrapper
  616.                 return self.admin_site.admin_view(view)(*args, **kwargs)
File "W:\.venv\citaty\lib\site-packages\django\utils\decorators.py" in _wrapped_view
  110.                     response = view_func(request, *args, **kwargs)
File "W:\.venv\citaty\lib\site-packages\django\views\decorators\cache.py" in _wrapped_view_func
  57.         response = view_func(request, *args, **kwargs)
File "W:\.venv\citaty\lib\site-packages\django\contrib\admin\sites.py" in inner
  233.             return view(request, *args, **kwargs)
File "W:\.venv\citaty\lib\site-packages\django\contrib\admin\options.py" in change_view
  1519.         return self.changeform_view(request, object_id, form_url, extra_context)
File "W:\.venv\citaty\lib\site-packages\django\utils\decorators.py" in _wrapper
  34.             return bound_func(*args, **kwargs)
File "W:\.venv\citaty\lib\site-packages\django\utils\decorators.py" in _wrapped_view
  110.                     response = view_func(request, *args, **kwargs)
File "W:\.venv\citaty\lib\site-packages\django\utils\decorators.py" in bound_func
  30.                 return func.__get__(self, type(self))(*args2, **kwargs2)
File "C:\Python34\Lib\contextlib.py" in inner
  30.                 return func(*args, **kwds)
File "W:\.venv\citaty\lib\site-packages\django\contrib\admin\options.py" in changeform_view
  1482.                 form = ModelForm(instance=obj)
File "W:/citaty\citaty\quotes\admin.py" in __init__
  62.         super(AuthorAdminEditForm, self).__init__(*args, **kwargs)
File "W:\github\django_parler\parler\forms.py" in __init__
  62.                         self.initial.setdefault(field, getattr(translation, field))
File "W:\.venv\citaty\lib\site-packages\django\db\models\fields\related.py" in __get__
  608.                 "%s has no %s." % (self.field.model.__name__, self.field.name)

Exception Type: RelatedObjectDoesNotExist at /admin/quotes/author/24610/
Exception Value: AuthorTranslation has no name.

```

# Fix
Add default `None` value when parler inicializing form with default form values.