### PR TITLE
Auto-derive PARLER_LANGUAGES from CMS_LANGUAGE, if present

### DIFF
--- a/parler/appsettings.py
+++ b/parler/appsettings.py
@@ -2,7 +2,10 @@
 Overview of all settings which can be customized.
 """
 from django.conf import settings
-from parler.utils import normalize_language_code
+from parler.utils import (
+    get_parler_languages_from_django_cms,
+    normalize_language_code,
+)
 from parler.utils.conf import add_default_language_settings
 
 
@@ -11,6 +14,11 @@ PARLER_DEFAULT_LANGUAGE_CODE = getattr(settings, 'PARLER_DEFAULT_LANGUAGE_CODE',
 PARLER_SHOW_EXCLUDED_LANGUAGE_TABS = getattr(settings, 'PARLER_SHOW_EXCLUDED_LANGUAGE_TABS', False)
 
 PARLER_LANGUAGES = getattr(settings, 'PARLER_LANGUAGES', {})
+
+if not PARLER_LANGUAGES:
+    if hasattr(settings, 'CMS_LANGUAGES'):
+        PARLER_LANGUAGES = get_parler_languages_from_django_cms(
+            getattr(settings, 'CMS_LANGUAGES'))
 
 PARLER_ENABLE_CACHING = getattr(settings, 'PARLER_ENABLE_CACHING', True)
 

--- a/parler/tests/test_utils.py
+++ b/parler/tests/test_utils.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from django.test import TestCase
+
+from parler.utils import get_parler_languages_from_django_cms
+
+
+class UtilTestCase(TestCase):
+    def test_get_parler_languages_from_django_cms(self):
+        cms = {
+            1: [
+                {
+                    'code': 'en',
+                    'fallbacks': ['es'],
+                    'hide_untranslated': True,
+                    'name': 'English',
+                    'public': True,
+                    'redirect_on_fallback': True
+                },
+                {
+                    'code': 'es',
+                    'fallbacks': ['en'],
+                    'hide_untranslated': True,
+                    'name': 'Spanish',
+                    'public': True,
+                    'redirect_on_fallback': True
+                },
+                {
+                    'code': 'fr',
+                    'fallbacks': ['en'],
+                    'hide_untranslated': True,
+                    'name': 'French',
+                    'public': True,
+                    'redirect_on_fallback': True
+                }
+            ],
+            'default': {
+                'fallbacks': ['en', ],
+                'hide_untranslated': True,
+                'public': True,
+                'redirect_on_fallback': True
+            }
+        }
+
+        parler = {
+            1: [
+                {
+                    'code': 'en',
+                    'fallbacks': ['es'],
+                    'hide_untranslated': True,
+                    'redirect_on_fallback': True
+                },
+                {
+                    'code': 'es',
+                    'fallbacks': ['en'],
+                    'hide_untranslated': True,
+                    'redirect_on_fallback': True
+                },
+                {
+                    'code': 'fr',
+                    'fallbacks': ['en'],
+                    'hide_untranslated': True,
+                    'redirect_on_fallback': True
+                }
+            ],
+            'default': {
+                'fallbacks': ['en', ],
+                'hide_untranslated': True,
+                'redirect_on_fallback': True
+            }
+        }
+
+        computed = get_parler_languages_from_django_cms(cms)
+        for block, block_config in computed.items():
+            self.assertEqual(cmp(computed[block], parler[block]), 0)

--- a/parler/utils/__init__.py
+++ b/parler/utils/__init__.py
@@ -11,6 +11,10 @@ from .i18n import (
     is_multilingual_project,
 )
 
+from .conf import (
+    get_parler_languages_from_django_cms,
+)
+
 __all__ = (
     'normalize_language_code',
     'is_supported_django_language',

--- a/parler/utils/conf.py
+++ b/parler/utils/conf.py
@@ -1,12 +1,15 @@
 """
 The configuration wrappers that are used for :ref:`PARLER_LANGUAGES`.
 """
+
+import copy
+import sys
+
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.utils import six
 from django.utils.translation import get_language
 from parler.utils.i18n import is_supported_django_language
-import warnings
 
 
 def add_default_language_settings(languages_list, var_name='PARLER_LANGUAGES', **extra_defaults):
@@ -174,3 +177,39 @@ class LanguagesSetting(dict):
             # No configuration, always fallback to default language.
             # This is essentially a non-multilingual configuration.
             return self['default']['code']
+
+
+def get_parler_languages_from_django_cms(cms_languages=None):
+    """
+    Converts django CMS' setting CMS_LANGUAGES into PARLER_LANGUAGES. Since
+    CMS_LANGUAGES is a strict superset of PARLER_LANGUAGES, we do a bit of
+    cleansing to remove irrelevant items.
+    """
+    valid_keys = ['code', 'fallbacks', 'hide_untranslated',
+                  'redirect_on_fallback']
+    if cms_languages:
+        if sys.version_info < (3, 0, 0):
+            int_types = (int, long)
+        else:
+            int_types = int
+
+        parler_languages = copy.deepcopy(cms_languages)
+        for site_id, site_config in parler_languages.items():
+            if site_id and (
+                    not isinstance(site_id, int_types) and
+                    site_id != 'default'
+            ):
+                del parler_languages[site_id]
+                continue
+
+            if site_id == 'default':
+                for key, value in site_config.items():
+                    if key not in valid_keys:
+                        del parler_languages['default'][key]
+            else:
+                for i, lang_config in enumerate(site_config):
+                    for key, value in lang_config.items():
+                        if key not in valid_keys:
+                            del parler_languages[site_id][i][key]
+        return parler_languages
+    return None


### PR DESCRIPTION
This will automatically derive PARLER_LANGUAGES from CMS_LANGUAGES if PARLER_LANGUAGES isn't already set and CMS_LANGUAGES is. This provides convenience for django CMS + Django Parler users, but also DRYer configurations.