### PR TITLE
django.contrib.admin.util trigger DeprecationWarning in 1.8, will disappear in 1.9

### DIFF
--- a/parler/admin.py
+++ b/parler/admin.py
@@ -42,7 +42,10 @@ from django.conf import settings
 from django.conf.urls import patterns, url
 from django.contrib import admin
 from django.contrib.admin.options import csrf_protect_m, BaseModelAdmin, InlineModelAdmin
-from django.contrib.admin.util import get_deleted_objects, unquote
+try:
+    from django.contrib.admin.utils import get_deleted_objects, unquote
+except ImportError:
+    from django.contrib.admin.util import get_deleted_objects, unquote
 from django.core.exceptions import PermissionDenied, ImproperlyConfigured
 from django.core.urlresolvers import reverse
 from django.db import router

--- a/parler/fields.py
+++ b/parler/fields.py
@@ -121,7 +121,7 @@ class TranslatedFieldDescriptor(object):
         """
         Ensure that the admin ``list_display`` renders the correct verbose name for translated fields.
 
-        The :func:`~django.contrib.admin.util.label_for_field` function
+        The :func:`~django.contrib.admin.utils.label_for_field` function
         uses :func:`~django.db.models.Options.get_field_by_name` to find the find and ``verbose_name``.
         However, for translated fields, this option does not exist,
         hence it falls back to reading the attribute and trying ``short_description``.

--- a/parler/tests/test_admin.py
+++ b/parler/tests/test_admin.py
@@ -1,5 +1,8 @@
 from __future__ import unicode_literals
-from django.contrib.admin.util import label_for_field
+try:
+    from django.contrib.admin.utils import label_for_field
+except ImportError:
+    from django.contrib.admin.util import label_for_field
 from .utils import AppTestCase
 from .testapp.models import SimpleModel, ConcreteModel, AbstractModel
 


### PR DESCRIPTION
Import from django.contrib.admin.utils (>= 1.9), and fallback to django.contrib.admin.util (< 1.9), to cope with the planned deprecation of 'util'