### PR TITLE
fallbacks: consider language variant as fallback language

### DIFF
--- a/parler/models.py
+++ b/parler/models.py
@@ -484,7 +484,7 @@ class TranslatableModel(models.Model):
             if not self._state.adding or self.pk is not None:
                 _cache_translation_needs_fallback(self, language_code, related_name=meta.rel_name)
 
-        fallback_choices = lang_dict['fallbacks']
+        fallback_choices = [lang_dict['code']] + lang_dict['fallbacks']
         if use_fallback and fallback_choices:
             # Jump to fallback language, return directly.
             # Don't cache under this language_code

--- a/parler/tests/test_model_attributes.py
+++ b/parler/tests/test_model_attributes.py
@@ -144,6 +144,21 @@ class ModelAttributeTests(AppTestCase):
             x = SimpleModel.objects.get(pk=x.pk)
             self.assertEqual(x.tr_title, 'TITLE_FALLBACK')
 
+    def test_fallback_variant(self):
+        """Test de-us falls back to de"""
+        x = SimpleModel()
+
+        x.set_current_language('en')
+        x.tr_title = "Hello"
+
+        x.set_current_language('de')
+        x.tr_title = "Hallo"
+        x.save()
+
+        with translation.override('de-ch'):
+            x = SimpleModel.objects.get(pk=x.pk)
+            self.assertEqual(x.tr_title, 'Hallo')
+
     def test_fallback_language_no_current(self):
         """
         Test whether the fallback language will be returned,

--- a/parler/utils/conf.py
+++ b/parler/utils/conf.py
@@ -107,6 +107,11 @@ class LanguagesSetting(dict):
             if lang_dict['code'] == language_code:
                 return lang_dict
 
+        # no language match, search for variant: fr-ca falls back to fr
+        for lang_dict in self.get(site_id, ()):
+            if lang_dict['code'].split('-')[0] == language_code.split('-')[0]:
+                return lang_dict
+
         return self['default']
 
 

--- a/parler/widgets.py
+++ b/parler/widgets.py
@@ -92,10 +92,11 @@ class SortedSelectMixin(object):
         else:
             return sorted(choices, key=_choicesorter)
 
+
 def _choicesorter(choice):
     if not choice[0]:
         # Allow empty choice to be first
-        return False
+        return ""
     else:
         # Lowercase to have case insensitive sorting.
         # For country list, normalize the strings (e.g. Österreich / Oman)


### PR DESCRIPTION
The PR aims to support language variant: `fr` is considered to be a fallback language of `fr-ca` (vice versa) while retrieving a translation for a model.

It refers to https://github.com/edoburu/django-parler/issues/106.