### PR TITLE
widgets: py3 compatible

### DIFF
--- a/parler/widgets.py
+++ b/parler/widgets.py
@@ -92,10 +92,11 @@ class SortedSelectMixin(object):
         else:
             return sorted(choices, key=_choicesorter)
 
+
 def _choicesorter(choice):
     if not choice[0]:
         # Allow empty choice to be first
-        return False
+        return ""
     else:
         # Lowercase to have case insensitive sorting.
         # For country list, normalize the strings (e.g. Österreich / Oman)


### PR DESCRIPTION
Comp keys must be the same type to avoid TypeError: unoraderable types.

Refers to issue https://github.com/edoburu/django-parler/issues/109