### PR TITLE
Django 1.9 support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+Changes in version 1.6.0 (2015-12-08)
+-------------------------------------
+
+* Added Django 1.9 support
+* Dropped support for Python < 2.7 and Django < 1.5
+
+
 Changes in version 1.5.1 (2015-10-01)
 -------------------------------------
 

--- a/example/article/templates/admin/article/change_form.html
+++ b/example/article/templates/admin/article/change_form.html
@@ -1,4 +1,4 @@
-{% extends "admin/change_form.html" %}{% load admin_urls i18n %}{% load url from future %}
+{% extends "admin/change_form.html" %}{% load admin_urls i18n %}
 
 {% comment %}
   A simple test to show that overriding templates still works.

--- a/example/article/tests.py
+++ b/example/article/tests.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 # from django.conf import settings
+import unittest
 import django
-from django.utils import encoding, translation, unittest
+from django.utils import encoding, translation
 from django.test import TestCase
 from django.contrib import auth
 from django.core.urlresolvers import reverse

--- a/example/theme1/templates/article/details.html
+++ b/example/theme1/templates/article/details.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}}{% load i18n parler_tags %}{% load url from future %}
+{% extends "base.html" %}}{% load i18n parler_tags %}
 
 {% block headtitle %}{{ article.title }}{% endblock %}
 

--- a/example/theme1/templates/article/list.html
+++ b/example/theme1/templates/article/list.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}{% load url from future %}
+{% extends "base.html" %}
 
 {% block headtitle %}List of articles{% endblock %}
 

--- a/example/theme1/templates/base.html
+++ b/example/theme1/templates/base.html
@@ -1,4 +1,4 @@
-{% load url from future %}<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xml:lang="{{ LANGUAGE_CODE|default:"en" }}" lang="{{ LANGUAGE_CODE|default:"en" }}">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />

--- a/parler/managers.py
+++ b/parler/managers.py
@@ -25,7 +25,10 @@ class TranslatableQuerySet(QuerySet):
 
 
     def _clone(self, klass=None, setup=False, **kw):
-        c = super(TranslatableQuerySet, self)._clone(klass, setup, **kw)
+        if django.VERSION < (1, 9):
+            kw['klass'] = klass
+            kw['setup'] = setup
+        c = super(TranslatableQuerySet, self)._clone(**kw)
         c._language = self._language
         return c
 

--- a/parler/models.py
+++ b/parler/models.py
@@ -60,7 +60,6 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured, ValidationError, FieldError, ObjectDoesNotExist
 from django.db import models, router
 from django.db.models.base import ModelBase
-from django.db.models.fields.related import ReverseSingleRelatedObjectDescriptor
 from django.utils.functional import lazy
 from django.utils.translation import get_language, ugettext, ugettext_lazy as _
 from django.utils import six
@@ -77,6 +76,10 @@ try:
 except ImportError:
     from django.utils.datastructures import SortedDict as OrderedDict
 
+if django.VERSION >= (1,9):
+    from django.db.models.fields.related_descriptors import ForwardManyToOneDescriptor
+else:
+    from django.db.models.fields.related import ReverseSingleRelatedObjectDescriptor as ForwardManyToOneDescriptor
 
 __all__ = (
     'TranslatableModel',
@@ -779,7 +782,7 @@ def _validate_master(new_class):
     """
     Check whether the 'master' field on a TranslatedFieldsModel is correctly configured.
     """
-    if not new_class.master or not isinstance(new_class.master, ReverseSingleRelatedObjectDescriptor):
+    if not new_class.master or not isinstance(new_class.master, ForwardManyToOneDescriptor):
         raise ImproperlyConfigured("{0}.master should be a ForeignKey to the shared table.".format(new_class.__name__))
 
     rel = new_class.master.field.rel

--- a/parler/tests/__init__.py
+++ b/parler/tests/__init__.py
@@ -1,8 +1,0 @@
-# Expose for Django 1.5 and below (before DiscoverRunner)
-from .test_admin import *
-from .test_model_construction import *
-from .test_model_attributes import *
-from .test_model_inheritance import *
-from .test_forms import *
-from .test_urls import *
-from .test_query_count import *

--- a/parler/tests/test_urls.py
+++ b/parler/tests/test_urls.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+import django
 from django.core.urlresolvers import reverse, resolve
 from django.test import RequestFactory
 from django.utils import translation
@@ -125,5 +126,10 @@ class UrlTests(AppTestCase):
         # Try call on the default slug (which is resolvable), although there is a translated version.
         with translation.override(self.other_lang2):
             response = self.client.get('/{0}/article/default/'.format(self.other_lang2))
-            self.assertEqual(response.status_code, 301, "Unexpected response, got: {0}, expected 301".format(response.content))
-            self.assertEqual(response['Location'], 'http://testserver/{0}/article/lang2/'.format(self.other_lang2))
+            if django.VERSION >= (1, 9):
+                self.assertRedirects(response, '/{0}/article/lang2/'.format(self.other_lang2), status_code=301)
+            elif django.VERSION >= (1, 7):
+                self.assertRedirects(response, 'http://testserver/{0}/article/lang2/'.format(self.other_lang2), status_code=301)
+            else:
+                self.assertEqual(response.status_code, 301, "Unexpected response, got: {0}, expected 301".format(response.content))
+                self.assertEqual(response['Location'], 'http://testserver/{0}/article/lang2/'.format(self.other_lang2))

--- a/parler/tests/testapp/invalid_models.py
+++ b/parler/tests/testapp/invalid_models.py
@@ -1,6 +1,6 @@
 from django.db import models
 from parler.models import TranslatableModel, TranslatedFields
-from parler.tests import RegularModel
+from parler.tests.testapp.models import RegularModel
 
 
 class RegularModelProxy(TranslatableModel, RegularModel):

--- a/parler/tests/utils.py
+++ b/parler/tests/utils.py
@@ -3,13 +3,22 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.management import call_command
 from django.contrib.sites.models import Site
-from django.db.models import loading
 from django.test import TestCase
 from django.test.utils import override_settings
-from django.utils.importlib import import_module
+from importlib import import_module
 import os
 from parler import appsettings
 
+def clear_cache():
+    """
+    Clear internal cache of apps loading 
+    """
+    if django.VERSION >= (1.7):
+        from django.db.models import loading
+        loading.cache.loaded = False
+    else:
+        from django.apps import apps
+        apps.clear_cache()
 
 class override_parler_settings(override_settings):
     """
@@ -57,7 +66,7 @@ class AppTestCase(TestCase):
 
                     # Flush caches
                     testapp = import_module(appname)
-                    loading.cache.loaded = False
+                    clear_cache()
                     app_directories.app_template_dirs += (
                         os.path.join(os.path.dirname(testapp.__file__), 'templates'),
                     )

--- a/runtests.py
+++ b/runtests.py
@@ -30,9 +30,9 @@ if not settings.configured:
             'django.template.loaders.app_directories.Loader',
             'django.template.loaders.filesystem.Loader',
         ),
-        TEMPLATE_CONTEXT_PROCESSORS = default_settings.TEMPLATE_CONTEXT_PROCESSORS + (
+        TEMPLATE_CONTEXT_PROCESSORS = list(default_settings.TEMPLATE_CONTEXT_PROCESSORS) + [
             'django.core.context_processors.request',
-        ),
+        ],
         INSTALLED_APPS = (
             'django.contrib.auth',
             'django.contrib.contenttypes',


### PR DESCRIPTION
{% load url from future %} dropped from example templates, as it is removed in Django 1.9
All tests are passed on Django 1.5, 1.6, 1.7, 1.8, 1.9