### PR TITLE
Force list for lang_dict['fallbacks']

### DIFF
--- a/parler/models.py
+++ b/parler/models.py
@@ -478,7 +478,7 @@ class TranslatableModel(models.Model):
             if not self._state.adding or self.pk is not None:
                 _cache_translation_needs_fallback(self, language_code, related_name=meta.rel_name)
 
-        fallback_choices = [lang_dict['code']] + lang_dict['fallbacks']
+        fallback_choices = [lang_dict['code']] + list(lang_dict['fallbacks'])
         if use_fallback and fallback_choices:
             # Jump to fallback language, return directly.
             # Don't cache under this language_code


### PR DESCRIPTION
This appears to be a regression from v1.5.x to v1.6.0

What is not clear is if this is the correct fix, but it should be benign regardless.

I think the real issue is that now fallbacks should be a list. The problem is if you don't explicitly set fallbacks in the settings dict, then Parler will do `fallbacks=settings.LANGUAGE_CODE`, but as a string, not as a list. Perhaps further fixes will be required so that Parler will set `fallbacks=[settings.LANGAUGE_CODE]` instead.

For those searching, the error one might get is: `TypeError: can only concatenate list (not "unicode") to list`. The work-around until this PR is merged and released is to explicitly set your fallbacks to something (even an empty list `[]`is fine), just don't let Parler do it for you.