### PR TITLE
Django 1.10 compatibility, removed Django 1.9 warnings

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,6 +11,7 @@ Contributors:
 * Iacopo Spalletti (@yakky)
 * Jacob Rief (@jrief)
 * Basil Shubin (@bashu)
+* Francesco Facconi (@mdsol)
 
 Inspired by:
 

--- a/parler/admin.py
+++ b/parler/admin.py
@@ -316,12 +316,12 @@ class TranslatableAdmin(BaseTranslatableAdmin, admin.ModelAdmin):
             opts = self.model._meta
             info = _get_model_meta(opts)
 
-            return patterns('',
+            return [
                 url(r'^(.+)/delete-translation/(.+)/$',
                     self.admin_site.admin_view(self.delete_translation),
                     name='{0}_{1}_delete_translation'.format(*info)
-                ),
-            ) + urlpatterns
+                    ),
+            ] + urlpatterns
 
     def render_change_form(self, request, context, add=False, change=False, form_url='', obj=None):
         """

--- a/parler/tests/utils.py
+++ b/parler/tests/utils.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 from django.conf import settings
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.core.management import call_command
 from django.contrib.sites.models import Site
 from django.test import TestCase
@@ -13,14 +13,23 @@ try:
 except ImportError:
     from django.utils.importlib import import_module  # Python 2.6
 
+try:
+    User = get_user_model()
+except ImportError:  # django < 1.5
+    from django.contrib.auth.models import User
+
 
 def clear_cache():
     """
     Clear internal cache of apps loading
     """
+    import django
     if django.VERSION >= (1.7):
-        from django.db.models import loading
-        loading.cache.loaded = False
+        try:
+            from django.db.models import loading
+            loading.cache.loaded = False
+        except ImportError:  # Django >= 1.9
+            pass
     else:
         from django.apps import apps
         apps.clear_cache()


### PR DESCRIPTION
Fixed "RemovedInDjango110Warning: django.conf.urls.patterns() is deprecated and will be removed in Django 1.10. Update your urlpatterns to be a list of django.conf.urls.url() instances instead." warning and added compatibility to Django 1.10.
All warnings in Django 1.9 have been fixed.