### PR TITLE
Add workaround for iteration over QS methods results that do not return QS of models

### DIFF
--- a/parler/managers.py
+++ b/parler/managers.py
@@ -107,7 +107,7 @@ class TranslatableQuerySet(QuerySet):
         # without breaking the result generators
         base_iterator = super(TranslatableQuerySet, self).iterator()
         for obj in base_iterator:
-            # Apply the language setting.
+            # Apply the language setting to model instances only.
             if self._language and isinstance(obj, models.Model):
                 obj.set_current_language(self._language)
 

--- a/parler/managers.py
+++ b/parler/managers.py
@@ -108,7 +108,7 @@ class TranslatableQuerySet(QuerySet):
         base_iterator = super(TranslatableQuerySet, self).iterator()
         for obj in base_iterator:
             # Apply the language setting.
-            if self._language:
+            if self._language and isinstance(obj, models.Model):
                 obj.set_current_language(self._language)
 
             yield obj

--- a/parler/tests/test_query_count.py
+++ b/parler/tests/test_query_count.py
@@ -1,3 +1,5 @@
+import datetime as dt
+
 from django.core.cache import cache
 from django.utils import translation
 from django.utils.timezone import now
@@ -64,14 +66,18 @@ class QueryCountTests(AppTestCase):
 
     def test_iteration_with_non_qs_methods(self):
         """
-        Test QuerySet methods that do not return QuerySets.
+        Test QuerySet methods that do not return QuerySets of models.
         """
-        obj = DateTimeModel.objects.first()
-        self.assertIn(obj,
-                      DateTimeModel.objects.language(self.conf_fallback).all())
-        self.assertIn(obj.datetime.date(),
-                      DateTimeModel.objects.language(self.conf_fallback).dates(
-                          'datetime', 'day'))
+        # We have at least one object created in setUpClass.
+        obj = DateTimeModel.objects.all()[0]
+        self.assertEqual(
+            obj,
+            DateTimeModel.objects.language(self.conf_fallback).all()[0])
+        # Test iteration through QuerySet of non-model objects.
+        self.assertIsInstance(
+            DateTimeModel.objects.language(self.conf_fallback).dates(
+                'datetime', 'day')[0],
+            dt.date)
 
     def test_prefetch_queries(self):
         """

--- a/parler/tests/testapp/models.py
+++ b/parler/tests/testapp/models.py
@@ -26,6 +26,18 @@ class SimpleModel(TranslatableModel):
         return self.tr_title
 
 
+class DateTimeModel(TranslatableModel):
+    shared = models.CharField(max_length=200, default='')
+    datetime = models.DateTimeField()
+
+    translations = TranslatedFields(
+        tr_title=models.CharField("Translated Title", max_length=200)
+    )
+
+    def __unicode__(self):
+        return self.tr_title
+
+
 class AnyLanguageModel(TranslatableModel):
     shared = models.CharField(max_length=200, default='')
     tr_title = TranslatedField(any_language=True)


### PR DESCRIPTION
Simple workaround for iteration over QuerySet methods results that do not return QuerySets of model insances.
For example: `.dates()`. This was an issue in django admin list view for me. Not sure what version it was introduced in, but it fails at least on Django 1.9.x.

Test case is just to prove the issue.