### PR TITLE
get_language_title: fallback to language code if language is not configured

### DIFF
--- a/parler/tests/test_model_attributes.py
+++ b/parler/tests/test_model_attributes.py
@@ -230,3 +230,24 @@ class ModelAttributeTests(AppTestCase):
             SimpleModel.objects.get(pk=x.pk)
         except TranslationDoesNotExist:
             self.fail("zero pk is not supported!")
+
+    def test_translatedfieldsmodel_str(self):
+        """Test converting TranslatedFieldsModel to string"""
+        missing_language_code = 'xx'
+        obj = SimpleModel.objects.create(tr_title='Something')
+
+        # Adjust translation object to use language_code that is not
+        # configured. It is easier because various Django version behave
+        # differently if we try to use not configured language.
+        translation = obj.translations.get()
+        translation.language_code = missing_language_code
+        translation.save()
+        # Try to get str() of the TranslatedFieldsModel instance.
+        try:
+            translation_as_str = str(obj.translations.get())
+        except KeyError:
+            self.fail("Converting translation to string raises KeyError")
+
+        # Check that we get language code as a fallback, when language is
+        # not configured.
+        self.assertEqual(translation_as_str, missing_language_code)

--- a/parler/tests/test_utils.py
+++ b/parler/tests/test_utils.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 from django.test import TestCase
 
 from parler.utils import get_parler_languages_from_django_cms
+from parler.utils.i18n import get_language_title
 
 
 class UtilTestCase(TestCase):
@@ -76,3 +77,18 @@ class UtilTestCase(TestCase):
         computed = get_parler_languages_from_django_cms(cms)
         for block, block_config in computed.items():
             self.assertEqual(computed[block], parler[block])
+
+    def test_get_language_title(self):
+        """Test get_language_title utility function"""
+        language_code = 'en'
+        self.assertEqual(get_language_title(language_code), 'English')
+
+        # Test the case where requested language is not in settings.
+        # We can not override settings, since languages in get_language_title()
+        # are initialised during import. So, we use fictional language code.
+        language_code = 'xx'
+        try:
+            self.assertEqual(get_language_title(language_code), language_code)
+        except KeyError:
+            self.fail(
+                "get_language_title() raises KeyError for missing language")

--- a/parler/utils/i18n.py
+++ b/parler/utils/i18n.py
@@ -43,6 +43,8 @@ def is_supported_django_language(language_code):
 def get_language_title(language_code):
     """
     Return the verbose_name for a language code.
+
+    Fallback to language_code if language is not found in settings.
     """
     from parler import appsettings
     # Avoid weird lookup errors.
@@ -60,7 +62,11 @@ def get_language_title(language_code):
         return _(languages[language_code])
     except KeyError:
         language_code = language_code.split('-')[0]  # e.g. if fr-ca is not supported fallback to fr
-        return _(languages[language_code])
+        language_title = languages.get(language_code, None)
+        if language_title is not None:
+            return _(language_title)
+        else:
+            return language_code
 
 
 def get_language_settings(language_code, site_id=None):


### PR DESCRIPTION
See #123 for retails.