### PR TITLE
Fix delete translation for Django 1.9+

### DIFF
--- a/parler/admin.py
+++ b/parler/admin.py
@@ -316,12 +316,20 @@ class TranslatableAdmin(BaseTranslatableAdmin, admin.ModelAdmin):
             opts = self.model._meta
             info = _get_model_meta(opts)
 
-            return [
-                url(r'^(.+)/delete-translation/(.+)/$',
+            if django.VERSION < (1, 9):
+                delete_path = url(
+                    r'^(.+)/delete-translation/(.+)/$',
                     self.admin_site.admin_view(self.delete_translation),
                     name='{0}_{1}_delete_translation'.format(*info)
-                    ),
-            ] + urlpatterns
+                )
+            else:
+                delete_path = url(
+                    r'^(.+)/change/delete-translation/(.+)/$',
+                    self.admin_site.admin_view(self.delete_translation),
+                    name='{0}_{1}_delete_translation'.format(*info)
+                )
+
+            return [delete_path] + urlpatterns
 
     def render_change_form(self, request, context, add=False, change=False, form_url='', obj=None):
         """
@@ -400,6 +408,7 @@ class TranslatableAdmin(BaseTranslatableAdmin, admin.ModelAdmin):
 
         # Get object and translation
         shared_obj = self.get_object(request, unquote(object_id))
+        print(object_id)
         if shared_obj is None:
             raise Http404
 

--- a/parler/admin.py
+++ b/parler/admin.py
@@ -408,7 +408,6 @@ class TranslatableAdmin(BaseTranslatableAdmin, admin.ModelAdmin):
 
         # Get object and translation
         shared_obj = self.get_object(request, unquote(object_id))
-        print(object_id)
         if shared_obj is None:
             raise Http404
 


### PR DESCRIPTION
Fix #122 by registering the appropriate url path according to the django version