### PR TITLE
Fix documentation about Django compatibility

### DIFF
--- a/docs/compatibility.rst
+++ b/docs/compatibility.rst
@@ -3,7 +3,7 @@ Django compatibility
 
 This package has been tested with:
 
-* Django versions 1.4, 1.5, 1.6 and 1.7
+* Django versions 1.5, 1.6, 1.7, 1.8 and 1.9
 * Python versions 2.6, 2.7, 3.3 and 3.4
 
 .. _orm-restrictions:


### PR DESCRIPTION
As I see in tox.ini versions tested are different than these described in the docs.