### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -200,4 +200,4 @@ Pull requests are welcome too. :-)
 .. _django-mptt: https://github.com/django-mptt/django-mptt
 .. _django-fluent-pages: https://github.com/edoburu/django-fluent-pages
 .. _django-polymorphic: https://github.com/chrisglass/django_polymorphic
-.. _documentation: http://django-parler.readthedocs.org/
+.. _documentation: https://django-parler.readthedocs.io/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -273,5 +273,5 @@ texinfo_documents = [
 intersphinx_mapping = {
     'http://docs.python.org/': None,
     'https://docs.djangoproject.com/en/dev': 'https://docs.djangoproject.com/en/dev/_objects',
-    'polymorphic': ('http://django-polymorphic.readthedocs.org/en/latest/', None),
+    'polymorphic': ('https://django-polymorphic.readthedocs.io/en/latest/', None),
 }


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.